### PR TITLE
feat: paper aesthetic redesign and remove CV nav link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,8 +15,5 @@ main:
   - title: "Blog Posts"
     url: /blogs/
     
-  - title: "CV"
-    url: "https://adityak2920.github.io/files/Aditya_CV.pdf"
-    
   - title: "Skills"
     url: /skills/

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,3 +1,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+<style>
+  body {
+    background-color: #f4edd8;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23noise)' opacity='0.05'/%3E%3C/svg%3E");
+  }
+</style>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -16,14 +16,10 @@ $indent-var : 1.3em;
 $serif : Georgia,
 Times,
 serif;
-$sans-serif : "Inter",
--apple-system,
-BlinkMacSystemFont,
-"Segoe UI",
-"Roboto",
-"Helvetica Neue",
-Arial,
-sans-serif;
+$sans-serif : "EB Garamond",
+Georgia,
+"Times New Roman",
+serif;
 $monospace : Monaco,
 Consolas,
 "Lucida Console",
@@ -50,7 +46,7 @@ serif;
 
 $global-font-family : $sans-serif;
 $header-font-family : $sans-serif;
-$caption-font-family : $serif;
+$caption-font-family : $sans-serif;
 
 /* type scale */
 $type-size-1 : 2em; // ~32px
@@ -73,14 +69,14 @@ $darker-gray : mix(#000, $gray, 60%);
 $light-gray : mix(#fff, $gray, 50%);
 $lighter-gray : mix(#fff, $gray, 90%);
 
-$body-color : #000;
-$background-color : #ffffff;
-$code-background-color : #fafafa;
+$body-color : #2c1d0e;
+$background-color : #f4edd8;
+$code-background-color : #ede3c4;
 $code-background-color-dark : $light-gray;
-$text-color : #000;
-$border-color : mix(#000, $background-color, 20%);
+$text-color : #2c1d0e;
+$border-color : #c8b898;
 
-$primary-color : #222;
+$primary-color : #3d2b1f;
 $success-color : #62c462;
 $warning-color : #f89406;
 $danger-color : #ee5f5b;
@@ -110,9 +106,9 @@ $xing-color : #006567;
 
 
 /* links */
-$link-color : mix(#000, $info-color, 15%) !default;
-$link-color-hover : mix(#000, $link-color, 25%) !default;
-$link-color-visited : mix(#fff, $link-color, 15%) !default;
+$link-color : #6b3a2a !default;
+$link-color-hover : #3d2b1f !default;
+$link-color-visited : #7a4b38 !default;
 $masthead-link-color : $primary-color !default;
 $masthead-link-color-hover : mix(#000, $primary-color, 25%) !default;
 $navicon-link-color-hover : mix(#fff, $primary-color, 75%) !default;


### PR DESCRIPTION
## Summary
- Remove CV link from navigation entirely
- Switch font from Inter to EB Garamond for a formal, document-like feel
- Apply warm parchment background (`#f4edd8`) with subtle SVG paper grain texture
- Update all text, border, and link colors to harmonious warm sepia tones (`#2c1d0e`, `#6b3a2a`, `#c8b898`)

## Test plan
- [ ] Verify CV no longer appears in nav
- [ ] Confirm parchment background and grain texture render correctly
- [ ] Check text readability across all pages
- [ ] Test on mobile — nav collapse still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)